### PR TITLE
Add yaml output of service account token to 06

### DIFF
--- a/exercises/06-using-service-account/solution/solution.md
+++ b/exercises/06-using-service-account/solution/solution.md
@@ -19,6 +19,29 @@ secrets:
 - name: backend-team-token-hskch
 ```
 
+To print the service account token in YAML format, take note of the secret name in the output of the previous command (in the last line). The token is part of this secret.
+
+```shell
+$ kubectl get secret backend-team-token-hskch -o yaml
+apiVersion: v1
+data:
+  ca.crt: [..]
+  namespace: ZGVmYXVsdA==
+  token: eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImJhY2tlbmQtdGVhbS10b2tlbi1kbTJmZCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJiYWNrZW5kLXRlYW0iLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiIxNzM0MzVjMS00NDJmLTExZTktOGRjMy0wMjUwMDAwMDAwMDEiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpiYWNrZW5kLXRlYW0ifQ.DjWUxEMNUmQVoXd4b-eIjxboj3w3k7hS5hfV8mm8eoEPz3HJJMgjIpAaurcvo1pp2Ggpd1kIhQvfRqI6-u57f80N5UqXt_qATJfonat2NNXX8pXmFNoPig9LB-pbo8TN_pYGWNworXsxmK9w6V9eaRosIinRp0u-cvijQbsBw3lxWgGo9S4G-7f19mMKN1Pg2xS2J6fKX9IKvhHrUkM91nwcwmsO0use5B4TGbuRa9METiGsfEpegvzMPBbPl0B_T1ANH_pck0LFNtvKe0g1v5zpKx2lRF9WdFAqPsG7BJ1dEH88JtBHzD59OhxIPqtyT4sXKjACBN_ka5ZADMzPJg
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: backend-team
+    kubernetes.io/service-account.uid: ecd3b7ea-72ab-11e9-96c5-025000000001
+  creationTimestamp: "2019-05-09T22:43:56Z"
+  name: backend-team-token-hskch
+  namespace: default
+  resourceVersion: "92198"
+  selfLink: /api/v1/namespaces/default/secrets/backend-team-token-hskch
+  uid: f74a7b59-cbf5-475b-85c0-debfbd83bb61
+type: kubernetes.io/service-account-token
+```
+
 Next, you can create a new Pod and assign the service account to it.
 
 ```shell


### PR DESCRIPTION
Hi,

thanks for this awesome guide!

While going through the exercises I noticed a missing step in exercise 06 which should output the token in YAML format. Inspecting the `serviceaccount` itself does not reveal the token.

Thanks
Malte