### PR TITLE
use env instead of /bin/sh

### DIFF
--- a/exercises/03-creating-using-secret/solution/solution.md
+++ b/exercises/03-creating-using-secret/solution/solution.md
@@ -46,7 +46,7 @@ $ kubectl create -f pod.yaml
 You can find the environment variable by shelling into the container and running the `env` command.
 
 ```shell
-$ kubectl exec -it backend -- /bin/sh
+$ kubectl exec -it backend -- env
 # env
 DB_PASSWORD=passwd
 # exit


### PR DESCRIPTION
In my exercise, using /bin/sh doesn't show the injected environment variables.
```
$ k exec backend -it -- /bin/sh
# env
KUBERNETES_SERVICE_PORT=443
KUBERNETES_PORT=tcp://172.21.0.1:443
HOSTNAME=backend
HOME=/root
PKG_RELEASE=1~buster
TERM=xterm
NGINX_VERSION=1.17.10
KUBERNETES_PORT_443_TCP_ADDR=172.21.0.1
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
NJS_VERSION=0.3.9
KUBERNETES_PORT_443_TCP_PORT=443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_SERVICE_PORT_HTTPS=443
KUBERNETES_PORT_443_TCP=tcp://172.21.0.1:443
KUBERNETES_SERVICE_HOST=172.21.0.1
PWD=/
# exit
$ k exec backend -it -- env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=backend
NGINX_VERSION=1.17.10
NJS_VERSION=0.3.9
PKG_RELEASE=1~buster
db-password=passwd
KUBERNETES_PORT_443_TCP_ADDR=172.21.0.1
KUBERNETES_SERVICE_HOST=172.21.0.1
KUBERNETES_SERVICE_PORT=443
KUBERNETES_SERVICE_PORT_HTTPS=443
KUBERNETES_PORT=tcp://172.21.0.1:443
KUBERNETES_PORT_443_TCP=tcp://172.21.0.1:443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_PORT_443_TCP_PORT=443
TERM=xterm
HOME=/root
```