### PR TITLE
Change memory requests to standard units

### DIFF
--- a/exercises/05-defining-resource-requirements/instructions.md
+++ b/exercises/05-defining-resource-requirements/instructions.md
@@ -15,7 +15,7 @@ spec:
   hard:
     pods: "2"
     requests.cpu: "2"
-    requests.memory: 500m
+    requests.memory: 500Mi
 ```
 
 1. Create a new Pod that exceeds the limits of the resource quota requirements e.g. by defining 1G of memory. Write down the error message.

--- a/exercises/05-defining-resource-requirements/solution/solution.md
+++ b/exercises/05-defining-resource-requirements/solution/solution.md
@@ -48,7 +48,7 @@ $ kubectl create -f pod.yaml --namespace=rq-demo
 Error from server (Forbidden): error when creating "pod.yaml": pods "mypod" is forbidden: exceeded quota: app, requested: requests.memory=1G, used: requests.memory=0, limited: requests.memory=500Mi
 ```
 
-Lower the memory settings to less than `500Mi` (e.g. `500M`) and create the Pod.
+Lower the memory settings to less than `500Mi` (e.g. `524M`) and create the Pod.
 
 ```shell
 $ kubectl create -f pod.yaml --namespace=rq-demo
@@ -60,5 +60,5 @@ Resource         Used  Hard
 --------         ----  ----
 pods             1     2
 requests.cpu     400m  2
-requests.memory  500M  500Mi
+requests.memory  524M  500Mi
 ```

--- a/exercises/05-defining-resource-requirements/solution/solution.md
+++ b/exercises/05-defining-resource-requirements/solution/solution.md
@@ -15,7 +15,7 @@ Resource         Used  Hard
 --------         ----  ----
 pods             0     2
 requests.cpu     0     2
-requests.memory  0     500m
+requests.memory  0     500Mi
 ```
 
 Next, create the YAML file named `pod.yaml` with more requested memory than available in the quota. You can start by running the command `kubectl run mypod --image=nginx -o yaml --dry-run=client --restart=Never > pod.yaml` and then edit the produced YAML file. Remember to _replace_ the `resources` attribute that has been created automatically.
@@ -45,10 +45,10 @@ Create the Pod and observe the error message.
 
 ```shell
 $ kubectl create -f pod.yaml --namespace=rq-demo
-Error from server (Forbidden): error when creating "pod.yaml": pods "mypod" is forbidden: exceeded quota: app, requested: requests.memory=1G, used: requests.memory=0, limited: requests.memory=500m
+Error from server (Forbidden): error when creating "pod.yaml": pods "mypod" is forbidden: exceeded quota: app, requested: requests.memory=1G, used: requests.memory=0, limited: requests.memory=500Mi
 ```
 
-Lower the memory settings to less than `500m` (e.g. `200m`) and create the Pod.
+Lower the memory settings to less than `500Mi` (e.g. `500M`) and create the Pod.
 
 ```shell
 $ kubectl create -f pod.yaml --namespace=rq-demo
@@ -60,5 +60,5 @@ Resource         Used  Hard
 --------         ----  ----
 pods             1     2
 requests.cpu     400m  2
-requests.memory  200m  500m
+requests.memory  500M  500Mi
 ```


### PR DESCRIPTION
Hi Benjamin,

Thanks a lot for these great exercises and for your course at O'Reilly!

I've noticed that you used `m` as unit for memory (request and quota). You talked about `m` as megabyte.
I've experimented a little bit with it and it turns out that `m` is actually not the same as `M` (megabyte).
```
Error from server (Forbidden): error when creating "pod.yaml": pods "mypod" is forbidden: exceeded quota: app, requested: requests.memory=300M, used: requests.memory=0, limited: requests.memory=500m
```
It looks like - as usual with Kubernetes -, that units are case sensitive too.
Valid memory units: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
Note: I'm not sure what `m` stands for, actually it's even a bit strange that works at all.. :)

In addition, in my proposal I've used both `M` and `Mi`, to make people aware of the difference between the megabyte and mebibyte units.

Hope you find it helpful!
Cheers,
Tamas