### PR TITLE
fix: Exercise 06 deprecated --serviceaccount flag fix

### DIFF
--- a/exercises/06-using-service-account/solution/solution.md
+++ b/exercises/06-using-service-account/solution/solution.md
@@ -22,7 +22,7 @@ secrets:
 Next, you can create a new Pod and assign the service account to it.
 
 ```shell
-$ kubectl run backend --image=nginx --restart=Never --serviceaccount=backend-team
+$ kubectl run backend --image=nginx --restart=Never --overrides='{ "spec": { "serviceAccount": "backend-team" } }'
 ```
 
 You can print out the token from the volume source at `/var/run/secrets/kubernetes.io/serviceaccount`.

--- a/exercises/06-using-service-account/solution/solution.md
+++ b/exercises/06-using-service-account/solution/solution.md
@@ -22,7 +22,7 @@ secrets:
 Next, you can create a new Pod and assign the service account to it.
 
 ```shell
-$ kubectl run backend --image=nginx --restart=Never --overrides='{ "spec": { "serviceAccount": "backend-team" } }'
+$ kubectl run backend --image=nginx --restart=Never --overrides='{ "spec": { "serviceAccountName": "backend-team" } }'
 ```
 
 You can print out the token from the volume source at `/var/run/secrets/kubernetes.io/serviceaccount`.


### PR DESCRIPTION
Replaced the deprecated --serviceaccount flag with another example of a one liner. 